### PR TITLE
Add option for users to provide their own axios instance

### DIFF
--- a/src/call.ts
+++ b/src/call.ts
@@ -35,7 +35,9 @@ const call = async <R, T>(
     req.data = opts.body;
   }
 
-  return await axios.request<T>({ url, ...req }).then((r) => r.data);
+  return await (opts.axios || axios)
+    .request<T>({ url, ...req })
+    .then((r) => r.data);
 };
 
 export default call;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,9 @@
+import { AxiosInstance } from 'axios';
+
 type AcquireTokenFunction = () => Promise<string>;
 
 export interface MobilixClientOptions {
   baseUrl: string;
   token?: string | AcquireTokenFunction;
+  axios?: AxiosInstance;
 }


### PR DESCRIPTION
This would allow mobilix-api-client users to set an axios instance with custom request / response interceptors for things like request logging