### PR TITLE
Replace deprecated querystring with URLSearchParams

### DIFF
--- a/src/endpoints/columnsets.ts
+++ b/src/endpoints/columnsets.ts
@@ -1,9 +1,7 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import type { MobilixClientOptions } from '../options';
-import type { ApiColumnSetRequest, ApiColumnSet } from '../api';
+import type { ApiColumnSet, ApiColumnSetRequest } from '../api';
 
 export interface ColumnSetOperations {
   list: (entity_type_id?: string) => Promise<ApiColumnSet[]>;
@@ -18,7 +16,7 @@ export const columnSetOperations = (
 ): ColumnSetOperations => ({
   list: async (entity_type_id) => {
     const qstring = entity_type_id
-      ? `?${querystring.stringify({ entity_type_id })}`
+      ? `?${new URLSearchParams({ entity_type_id }).toString()}`
       : '';
     return await call<undefined, ApiColumnSet[]>(
       'GET',

--- a/src/endpoints/contractor_agents.ts
+++ b/src/endpoints/contractor_agents.ts
@@ -1,9 +1,7 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import { MobilixClientOptions } from '../options';
-import { ApiContractorAgentRequest, ApiContractorAgent } from '../api';
+import { ApiContractorAgent, ApiContractorAgentRequest } from '../api';
 
 export interface ContractorAgentOperations {
   list: (contractor_id?: string) => Promise<ApiContractorAgent[]>;
@@ -21,7 +19,7 @@ export const contractorAgentOperations = (
 ): ContractorAgentOperations => ({
   list: async (contractor_id) => {
     const qstring = contractor_id
-      ? `?${querystring.stringify({ contractor_id })}`
+      ? `?${new URLSearchParams({ contractor_id }).toString()}`
       : '';
     return await call<undefined, ApiContractorAgent[]>(
       'GET',

--- a/src/endpoints/entities.ts
+++ b/src/endpoints/entities.ts
@@ -1,15 +1,13 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import { MobilixClientOptions } from '../options';
 import {
   ApiAttachment,
-  ApiEntityRequest,
-  ApiEntityEventClientRequest,
   ApiEntity,
-  ApiEntityEvent,
   ApiEntityChangeSet,
+  ApiEntityEvent,
+  ApiEntityEventClientRequest,
+  ApiEntityRequest,
 } from '../api';
 
 export interface EntityOperations {
@@ -41,7 +39,7 @@ export const entityOperations = (
 ): EntityOperations => ({
   list: async (entity_type_id) => {
     const qstring = entity_type_id
-      ? `?${querystring.stringify({ entity_type_id })}`
+      ? `?${new URLSearchParams({ entity_type_id }).toString()}`
       : '';
     return await call<undefined, ApiEntity[]>('GET', `/entities${qstring}`, {
       ...opts,

--- a/src/endpoints/error_reports.ts
+++ b/src/endpoints/error_reports.ts
@@ -1,9 +1,7 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import type { MobilixClientOptions } from '../options';
-import type { ApiErrorReportRequest, ApiErrorReport } from '../api';
+import type { ApiErrorReport, ApiErrorReportRequest } from '../api';
 
 export interface ErrorReportOperations {
   list: (entity_id?: string) => Promise<ApiErrorReport[]>;
@@ -16,7 +14,9 @@ export const errorReportOperations = (
   opts: MobilixClientOptions,
 ): ErrorReportOperations => ({
   list: async (entity_id) => {
-    const qstring = entity_id ? `?${querystring.stringify({ entity_id })}` : '';
+    const qstring = entity_id
+      ? `?${new URLSearchParams({ entity_id }).toString()}`
+      : '';
     return await call<undefined, ApiErrorReport[]>(
       'GET',
       `/error_reports${qstring}`,

--- a/src/endpoints/filtersets.ts
+++ b/src/endpoints/filtersets.ts
@@ -1,9 +1,7 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import type { MobilixClientOptions } from '../options';
-import type { ApiFilterSetRequest, ApiFilterSet } from '../api';
+import type { ApiFilterSet, ApiFilterSetRequest } from '../api';
 
 export interface FilterSetOperations {
   list: (entity_type_id?: string) => Promise<ApiFilterSet[]>;
@@ -18,7 +16,7 @@ export const filterSetOperations = (
 ): FilterSetOperations => ({
   list: async (entity_type_id) => {
     const qstring = entity_type_id
-      ? `?${querystring.stringify({ entity_type_id })}`
+      ? `?${new URLSearchParams({ entity_type_id }).toString()}`
       : '';
     return await call<undefined, ApiFilterSet[]>(
       'GET',

--- a/src/endpoints/workorders.ts
+++ b/src/endpoints/workorders.ts
@@ -1,15 +1,13 @@
-import querystring from 'querystring';
-
 import call from '../call';
 
 import type { MobilixClientOptions } from '../options';
 import type {
-  ApiWorkOrderRequest,
-  ApiWorkOrder,
-  ApiWorkOrderEventClientRequest,
-  ApiWorkOrderEvent,
-  ApiWorkOrderState,
   ApiAttachment,
+  ApiWorkOrder,
+  ApiWorkOrderEvent,
+  ApiWorkOrderEventClientRequest,
+  ApiWorkOrderRequest,
+  ApiWorkOrderState,
 } from '../api';
 
 export interface WorkOrderOperations {
@@ -30,7 +28,9 @@ export const workOrderOperations = (
   opts: MobilixClientOptions,
 ): WorkOrderOperations => ({
   list: async (state) => {
-    const qstring = state ? `?${querystring.stringify({ state })}` : '';
+    const qstring = state
+      ? `?${new URLSearchParams({ state }).toString()}`
+      : '';
     return await call<undefined, ApiWorkOrder[]>(
       'GET',
       `/workorders${qstring}`,


### PR DESCRIPTION
querystring does not seem to work well with ReactNative in Expo mode